### PR TITLE
Add proper compile pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,11 @@ script:
 - coverage run -a --source=uplc -m uplc build examples/fibonacci.uplc
 - coverage run -a --source=uplc -m uplc build examples/fibonacci.uplc -fremove-traces
 - coverage run -a --source=uplc -m uplc build examples/fibonacci.uplc -fconstant-folding
+- coverage run -a --source=uplc -m uplc build examples/fibonacci.uplc -fremove-force-delay
+- coverage run -a --source=uplc -m uplc build examples/fibonacci.uplc -O0
+- coverage run -a --source=uplc -m uplc build examples/fibonacci.uplc -O1
+- coverage run -a --source=uplc -m uplc build examples/fibonacci.uplc -O2
+- coverage run -a --source=uplc -m uplc build examples/fibonacci.uplc -O3
 - coverage run -a --source=uplc -m uplc dump build/fibonacci/script.cbor --from-cbor
 after_success:
 - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ script:
 - coverage run -a --source=uplc -m uplc dump examples/fibonacci.uplc --dialect plutus --unique-varnames
 - coverage run -a --source=uplc -m uplc eval examples/fibonacci.uplc "(con integer 5)"
 - coverage run -a --source=uplc -m uplc build examples/fibonacci.uplc
+- coverage run -a --source=uplc -m uplc build examples/fibonacci.uplc -fremove-traces
+- coverage run -a --source=uplc -m uplc build examples/fibonacci.uplc -fconstant-folding
 - coverage run -a --source=uplc -m uplc dump build/fibonacci/script.cbor --from-cbor
 after_success:
 - coverage report

--- a/uplc/__main__.py
+++ b/uplc/__main__.py
@@ -138,6 +138,14 @@ def get_args():
             dest=k,
             default=None,
         )
+    a.add_argument(
+        "-O",
+        default=1,
+        type=int,
+        help="The optimization level to use. Choose between 0 (nothing) and 3 (aggressive, semantics changing). Defaults to 1.",
+        choices=range(len(OPT_CONFIGS)),
+        dest="opt_level",
+    )
     return a.parse_args()
 
 
@@ -147,6 +155,7 @@ def main():
 
     # generate the compiler config
     compiler_config = DEFAULT_CONFIG
+    compiler_config = compiler_config.update(OPT_CONFIGS[args.opt_level])
     overrides = {}
     for k in ARGPARSE_ARGS.keys():
         if getattr(args, k) is not None:

--- a/uplc/__main__.py
+++ b/uplc/__main__.py
@@ -147,7 +147,6 @@ def main():
 
     # generate the compiler config
     compiler_config = DEFAULT_CONFIG
-    compiler_config = compiler_config.update(OPT_CONFIGS[args.opt_level])
     overrides = {}
     for k in ARGPARSE_ARGS.keys():
         if getattr(args, k) is not None:

--- a/uplc/compiler_config.py
+++ b/uplc/compiler_config.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+from typing import Optional, Union
+
+
+@dataclass(frozen=True)
+class CompilationConfig:
+    constant_folding: Optional[bool] = None
+
+    def update(
+        self, other: Optional["CompilationConfig"] = None, **kwargs
+    ) -> "CompilationConfig":
+        own_dict = self.__dict__
+        other_dict = other.__dict__ if isinstance(other, CompilationConfig) else kwargs
+        return self.__class__(
+            **{
+                k: other_dict.get(k) if other_dict.get(k) is not None else own_dict[k]
+                for k in own_dict
+            }
+        )
+
+
+# The default configuration for the compiler
+OPT_O0_CONFIG = CompilationConfig()
+OPT_O1_CONFIG = OPT_O0_CONFIG.update()
+OPT_O2_CONFIG = OPT_O1_CONFIG.update(constant_folding=True)
+OPT_O3_CONFIG = OPT_O2_CONFIG.update()
+OPT_CONFIGS = [OPT_O0_CONFIG, OPT_O1_CONFIG, OPT_O2_CONFIG, OPT_O3_CONFIG]
+
+DEFAULT_CONFIG = CompilationConfig().update(OPT_O1_CONFIG)
+
+ARGPARSE_ARGS = {
+    "unique_variable_names": {
+        "__alts__": ["--unique-varnames"],
+        "help": "Assign variables a unique name.",
+    },
+    "constant_folding": {
+        "__alts__": ["--cf"],
+        "help": "Enables experimental constant folding, including propagation and code execution.",
+    },
+}
+for k in ARGPARSE_ARGS:
+    assert (
+        k in DEFAULT_CONFIG.__dict__
+    ), f"Key {k} not found in CompilationConfig.__dict__"

--- a/uplc/compiler_config.py
+++ b/uplc/compiler_config.py
@@ -5,6 +5,8 @@ from typing import Optional, Union
 @dataclass(frozen=True)
 class CompilationConfig:
     constant_folding: Optional[bool] = None
+    unique_variable_names: Optional[bool] = None
+    remove_traces: Optional[bool] = None
 
     def update(
         self, other: Optional["CompilationConfig"] = None, **kwargs
@@ -23,12 +25,15 @@ class CompilationConfig:
 OPT_O0_CONFIG = CompilationConfig()
 OPT_O1_CONFIG = OPT_O0_CONFIG.update()
 OPT_O2_CONFIG = OPT_O1_CONFIG.update(constant_folding=True)
-OPT_O3_CONFIG = OPT_O2_CONFIG.update()
+OPT_O3_CONFIG = OPT_O2_CONFIG.update(remove_traces=True)
 OPT_CONFIGS = [OPT_O0_CONFIG, OPT_O1_CONFIG, OPT_O2_CONFIG, OPT_O3_CONFIG]
 
-DEFAULT_CONFIG = CompilationConfig().update(OPT_O1_CONFIG)
+DEFAULT_CONFIG = CompilationConfig(unique_variable_names=False).update(OPT_O1_CONFIG)
 
 ARGPARSE_ARGS = {
+    "remove_traces": {
+        "help": "Remove traces from the compiled contract.",
+    },
     "unique_variable_names": {
         "__alts__": ["--unique-varnames"],
         "help": "Assign variables a unique name.",

--- a/uplc/compiler_config.py
+++ b/uplc/compiler_config.py
@@ -7,6 +7,7 @@ class CompilationConfig:
     constant_folding: Optional[bool] = None
     unique_variable_names: Optional[bool] = None
     remove_traces: Optional[bool] = None
+    remove_force_delay: Optional[bool] = None
 
     def update(
         self, other: Optional["CompilationConfig"] = None, **kwargs
@@ -23,7 +24,7 @@ class CompilationConfig:
 
 # The default configuration for the compiler
 OPT_O0_CONFIG = CompilationConfig()
-OPT_O1_CONFIG = OPT_O0_CONFIG.update()
+OPT_O1_CONFIG = OPT_O0_CONFIG.update(remove_force_delay=True)
 OPT_O2_CONFIG = OPT_O1_CONFIG.update(constant_folding=True)
 OPT_O3_CONFIG = OPT_O2_CONFIG.update(remove_traces=True)
 OPT_CONFIGS = [OPT_O0_CONFIG, OPT_O1_CONFIG, OPT_O2_CONFIG, OPT_O3_CONFIG]
@@ -41,6 +42,10 @@ ARGPARSE_ARGS = {
     "constant_folding": {
         "__alts__": ["--cf"],
         "help": "Enables experimental constant folding, including propagation and code execution.",
+    },
+    "remove_force_delay": {
+        "__alts__": ["--rfd"],
+        "help": "Removes delayed terms that are immediately forced.",
     },
 }
 for k in ARGPARSE_ARGS:

--- a/uplc/optimizer/pre_evaluation.py
+++ b/uplc/optimizer/pre_evaluation.py
@@ -1,6 +1,5 @@
-from ..util import NodeTransformer
-from ..ast import Program, AST
-from ..tools import eval
+from ..util import NodeTransformer, NodeVisitor
+from ..ast import Program, AST, ForcedBuiltIn, BuiltInFun
 
 """
 Optimizes code by pre-evaluating each subterm
@@ -8,13 +7,35 @@ If it throws an error, assume it is not safe to pre-evaluate and don't replace, 
 """
 
 
+class TraceFinder(NodeVisitor):
+    found = False
+
+    def visit_ForcedBuiltIn(self, node: ForcedBuiltIn):
+        if node.builtin == BuiltInFun.Trace:
+            self.found = True
+            return
+        return
+
+    def contains_trace(self, node: AST) -> bool:
+        self.visit(node)
+        return self.found
+
+
 class PreEvaluationOptimizer(NodeTransformer):
+    def __init__(self, skip_traces: bool = True):
+        from ..tools import eval
+
+        self.eval = eval
+        self.skip_traces = skip_traces
+
     def visit_Program(self, node: Program) -> Program:
         return Program(version=node.version, term=self.visit(node.term))
 
     def generic_visit(self, node: AST) -> AST:
+        if self.skip_traces and TraceFinder().contains_trace(node):
+            return super().generic_visit(node)
         try:
-            nc = eval(node).result
+            nc = self.eval(node).result
         except Exception as e:
             nc = node
         else:

--- a/uplc/optimizer/remove_force_delay.py
+++ b/uplc/optimizer/remove_force_delay.py
@@ -1,0 +1,13 @@
+from ..util import NodeTransformer
+from ..ast import *
+
+"""
+Removes occurrences of force(delay(x)) and replaces them with x
+"""
+
+
+class ForceDelayRemover(NodeTransformer):
+    def visit_Force(self, node: Force):
+        if isinstance(node.term, Delay):
+            return self.visit(node.term.term)
+        return super().generic_visit(node)

--- a/uplc/optimizer/remove_traces.py
+++ b/uplc/optimizer/remove_traces.py
@@ -1,0 +1,13 @@
+from ..util import NodeTransformer
+from ..ast import Apply, ForcedBuiltIn, BuiltInFun
+
+"""
+Removes traces from the AST, as traces have only side-effects and no value
+"""
+
+
+class TraceRemover(NodeTransformer):
+    def visit_Apply(self, node: Apply):
+        if isinstance(node.f, ForcedBuiltIn) and node.f.builtin == BuiltInFun.Trace:
+            return self.visit(node.x)
+        return Apply(f=self.visit(node.f), x=self.visit(node.x))

--- a/uplc/optimizer/remove_traces.py
+++ b/uplc/optimizer/remove_traces.py
@@ -1,5 +1,5 @@
 from ..util import NodeTransformer
-from ..ast import Apply, ForcedBuiltIn, BuiltInFun
+from ..ast import Apply, ForcedBuiltIn, BuiltInFun, Lambda, Delay, Variable
 
 """
 Removes traces from the AST, as traces have only side-effects and no value
@@ -7,7 +7,10 @@ Removes traces from the AST, as traces have only side-effects and no value
 
 
 class TraceRemover(NodeTransformer):
-    def visit_Apply(self, node: Apply):
-        if isinstance(node.f, ForcedBuiltIn) and node.f.builtin == BuiltInFun.Trace:
-            return self.visit(node.x)
-        return Apply(f=self.visit(node.f), x=self.visit(node.x))
+    def visit_BuiltIn(self, node: Apply):
+        return self.visit_ForcedBuiltIn(node)
+
+    def visit_ForcedBuiltIn(self, node: ForcedBuiltIn):
+        if node.builtin == BuiltInFun.Trace:
+            return Delay(term=Lambda("y", Lambda("x", Variable("x"))))
+        return node

--- a/uplc/tests/test_acceptance.py
+++ b/uplc/tests/test_acceptance.py
@@ -92,15 +92,14 @@ class AcceptanceTests(unittest.TestCase):
             return
         cost = json.loads(cost_content)
         expected_spent_budget = Budget(cost["cpu"], cost["mem"])
-        if rewriter in (
-            pre_evaluation.PreEvaluationOptimizer,
-            remove_traces.TraceRemover,
-        ):
+        if rewriter == pre_evaluation.PreEvaluationOptimizer:
             self.assertGreaterEqual(
                 expected_spent_budget,
                 comp_res.cost,
                 "Program cost more after preeval/trace removal rewrite",
             )
+        elif rewriter == remove_traces.TraceRemover:
+            pass
         else:
             self.assertEqual(
                 expected_spent_budget,

--- a/uplc/tests/test_acceptance.py
+++ b/uplc/tests/test_acceptance.py
@@ -9,7 +9,7 @@ from .. import parse, dumps, UPLCDialect, eval
 from ..cost_model import Budget
 from ..util import NodeTransformer
 from ..transformer import unique_variables
-from ..optimizer import pre_evaluation
+from ..optimizer import pre_evaluation, remove_traces
 
 acceptance_test_path = Path("examples/acceptance_tests")
 
@@ -31,6 +31,8 @@ rewriters = [
     unique_variables.UniqueVariableTransformer,
     # Pre-evaluating subterms - here it will always evaluate the whole expression as there are no missing variables
     pre_evaluation.PreEvaluationOptimizer,
+    # Trace removal
+    remove_traces.TraceRemover,
 ]
 
 
@@ -90,11 +92,14 @@ class AcceptanceTests(unittest.TestCase):
             return
         cost = json.loads(cost_content)
         expected_spent_budget = Budget(cost["cpu"], cost["mem"])
-        if rewriter == pre_evaluation.PreEvaluationOptimizer:
+        if rewriter in (
+            pre_evaluation.PreEvaluationOptimizer,
+            remove_traces.TraceRemover,
+        ):
             self.assertGreaterEqual(
                 expected_spent_budget,
                 comp_res.cost,
-                "Program cost more after preeval rewrite",
+                "Program cost more after preeval/trace removal rewrite",
             )
         else:
             self.assertEqual(

--- a/uplc/tests/test_acceptance.py
+++ b/uplc/tests/test_acceptance.py
@@ -9,7 +9,7 @@ from .. import parse, dumps, UPLCDialect, eval
 from ..cost_model import Budget
 from ..util import NodeTransformer
 from ..transformer import unique_variables
-from ..optimizer import pre_evaluation, remove_traces
+from ..optimizer import pre_evaluation, remove_traces, remove_force_delay
 
 acceptance_test_path = Path("examples/acceptance_tests")
 
@@ -33,6 +33,8 @@ rewriters = [
     pre_evaluation.PreEvaluationOptimizer,
     # Trace removal
     remove_traces.TraceRemover,
+    # Force Delay Removal
+    remove_force_delay.ForceDelayRemover,
 ]
 
 
@@ -92,7 +94,10 @@ class AcceptanceTests(unittest.TestCase):
             return
         cost = json.loads(cost_content)
         expected_spent_budget = Budget(cost["cpu"], cost["mem"])
-        if rewriter == pre_evaluation.PreEvaluationOptimizer:
+        if rewriter in (
+            pre_evaluation.PreEvaluationOptimizer,
+            remove_force_delay.ForceDelayRemover,
+        ):
             self.assertGreaterEqual(
                 expected_spent_budget,
                 comp_res.cost,

--- a/uplc/tests/test_misc.py
+++ b/uplc/tests/test_misc.py
@@ -1671,3 +1671,49 @@ class MiscTest(unittest.TestCase):
         self.assertEqual(
             r.result, BuiltinUnit(), "Trace did not return second argument"
         )
+
+    def test_trace_removal_preeval(self):
+        x = "Hello, world!"
+        y = "Hello, world 2!"
+        p = Program(
+            (1, 0, 0),
+            Apply(
+                Apply(Force(BuiltIn(BuiltInFun.Trace)), BuiltinString(value=y)),
+                Apply(
+                    Apply(Force(BuiltIn(BuiltInFun.Trace)), BuiltinString(value=x)),
+                    BuiltinUnit(),
+                ),
+            ),
+        )
+        p = pre_evaluation.PreEvaluationOptimizer(skip_traces=False).visit(p)
+        r = eval(p)
+        self.assertNotIn(
+            x, r.logs, "Trace was produced even though rewrite should have removed it"
+        )
+        self.assertNotIn(y, r.logs, "Trace did not produce a log for second message.")
+        self.assertEqual(r.logs, [], "Trace did log.")
+        self.assertEqual(
+            r.result, BuiltinUnit(), "Trace did not return second argument"
+        )
+
+    def test_no_trace_removal_preeval(self):
+        x = "Hello, world!"
+        y = "Hello, world 2!"
+        p = Program(
+            (1, 0, 0),
+            Apply(
+                Apply(Force(BuiltIn(BuiltInFun.Trace)), BuiltinString(value=y)),
+                Apply(
+                    Apply(Force(BuiltIn(BuiltInFun.Trace)), BuiltinString(value=x)),
+                    BuiltinUnit(),
+                ),
+            ),
+        )
+        p = pre_evaluation.PreEvaluationOptimizer(skip_traces=True).visit(p)
+        r = eval(p)
+        self.assertIn(x, r.logs, "Trace did not produce a log for first message.")
+        self.assertIn(y, r.logs, "Trace did not produce a log for second message.")
+        self.assertEqual(r.logs, [x, y], "Trace did log in correct order.")
+        self.assertEqual(
+            r.result, BuiltinUnit(), "Trace did not return second argument"
+        )

--- a/uplc/tests/test_misc.py
+++ b/uplc/tests/test_misc.py
@@ -4,8 +4,10 @@ import rply.parser
 from parameterized import parameterized
 
 from .. import *
+from .. import compiler_config
+from ..tools import apply
 from ..transformer import unique_variables
-from ..optimizer import pre_evaluation, remove_traces
+from ..optimizer import pre_evaluation, remove_traces, remove_force_delay
 from ..lexer import strip_comments
 from ..ast import *
 
@@ -1717,3 +1719,25 @@ class MiscTest(unittest.TestCase):
         self.assertEqual(
             r.result, BuiltinUnit(), "Trace did not return second argument"
         )
+
+    def test_force_delay_removal(self):
+        p = Program((1, 0, 0), Force(Delay(Error())))
+        p = remove_force_delay.ForceDelayRemover().visit(p)
+        self.assertEqual(p.term, Error(), "Force-Delay was not removed.")
+
+    def test_compiler_options(self):
+        with open("examples/fibonacci.uplc", "r") as f:
+            p = parse(f.read())
+        p1 = tools.compile(p, compiler_config.OPT_O0_CONFIG)
+        p2 = tools.compile(p, compiler_config.OPT_O3_CONFIG)
+        self.assertNotEquals(
+            p1.dumps(), p2.dumps(), "Compiler options did not change the program."
+        )
+        for i in range(5):
+            r1 = eval(apply(p1, BuiltinInteger(i)))
+            r2 = eval(apply(p2, BuiltinInteger(i)))
+            self.assertEqual(
+                r1.result,
+                r2.result,
+                "Compiler options did not produce the same result.",
+            )

--- a/uplc/tools.py
+++ b/uplc/tools.py
@@ -12,6 +12,7 @@ from .cost_model import (
 )
 from .lexer import strip_comments, Lexer
 from .optimizer.pre_evaluation import PreEvaluationOptimizer
+from .optimizer.remove_traces import TraceRemover
 from .parser import Parser
 from .machine import Machine
 from .ast import AST, UPLCDialect, Program, plutus_cbor_dumps, PlutusByteString
@@ -91,7 +92,11 @@ def compile(
     """
     for step in [
         UniqueVariableTransformer() if config.unique_variable_names else NoOp(),
-        PreEvaluationOptimizer() if config.constant_folding else NoOp(),
+        TraceRemover() if config.remove_traces else NoOp(),
+        PreEvaluationOptimizer(skip_traces=not config.remove_traces)
+        if config.constant_folding
+        else NoOp(),
+        TraceRemover() if config.remove_traces else NoOp(),
     ]:
         x = step.visit(x)
     x = x.compile()

--- a/uplc/util.py
+++ b/uplc/util.py
@@ -79,3 +79,9 @@ class NodeTransformer(NodeVisitor):
             else:
                 setattr(node, field, new_node)
         return node
+
+
+class NoOp(NodeTransformer):
+    """A variation of the Node transformer that performs no changes"""
+
+    pass


### PR DESCRIPTION
This PR adds a compilation pipeline similar to Pluthon and Opshin. However this is more a glorified way of applying optimizations. Consistent with Opshin and Pluthon optimizations can be turned on and off using command line flags.

This also introduces two optimizations, a remover of Trace operations (which is an O3 optimization as it changes semantics) and a remover of Force(Delay(x)) constructs that have no semantic effect.

Moreover this closes #26 with a restricted (and thus safer) version, that checks whether the evaluation result is a constant or similar value that can be safely constant folded.